### PR TITLE
Page.save_bot_start_end: avoid use of re.sub to prevent re.error

### DIFF
--- a/src/pywikibot_extensions/page.py
+++ b/src/pywikibot_extensions/page.py
@@ -142,8 +142,10 @@ class Page(pywikibot.Page):
             return
         text = text.strip()
         current_text = self.text  # type: ignore[has-type]
-        if self.BOT_START_END.match(current_text):
-            self.text = self.BOT_START_END.sub(rf"\1\n{text}\3", current_text)
+        match_ = self.BOT_START_END.match(current_text)
+        if match_:
+            # re.sub will raise if text contains a bad escape
+            self.text = f"{match_.group(1)}\n{text}{match_.group(3)}"
         else:
             self.text = text
         self.save(minor=minor, botflag=botflag, force=force, **kwargs)

--- a/tests/page_test.py
+++ b/tests/page_test.py
@@ -247,11 +247,11 @@ def test_page_is_article_catches_exception(mocker: MockerFixture) -> None:
             "Test",
         ),
         (
-            "Test",
+            r"\Poof",
             "<!--bot start-->Old<!--bot end-->",
             True,
             False,
-            "<!--bot start-->\nTest<!--bot end-->",
+            "<!--bot start-->\n\\Poof<!--bot end-->",
         ),
         (
             "\n* One\n* Two\n* Three",


### PR DESCRIPTION
re.sub will raise if text contains a bad escape