### PR TITLE
override Page.get() to ignore SectionError

### DIFF
--- a/src/pywikibot_extensions/page.py
+++ b/src/pywikibot_extensions/page.py
@@ -14,6 +14,7 @@ from functools import lru_cache
 from typing import Any, TypeVar, Union
 
 import pywikibot
+import pywikibot.exceptions
 from pywikibot.site import Namespace
 from pywikibot.textlib import removeDisabledParts
 
@@ -56,6 +57,14 @@ class Page(pywikibot.Page):
         r"^(.*?<!--\s*bot start\s*-->)(.*?)(<!--\s*bot end\s*-->.*)$",
         flags=re.I | re.S,
     )
+
+    def get(self, force: bool = False, get_redirect: bool = False) -> str:
+        """Return the wiki-text of the page."""
+        try:
+            text: str = super().get(force, get_redirect)
+        except pywikibot.exceptions.SectionError:  # T422859
+            text = self.latest_revision.text
+        return text
 
     @classmethod
     def from_wikilink(

--- a/tests/page_test.py
+++ b/tests/page_test.py
@@ -96,6 +96,17 @@ def test_get_redirects_for_redirect(mocker: MockerFixture) -> None:
     assert get_redirects(frozenset([test_page])) == expected
 
 
+def test_page_get_sectionerror(mocker: MockerFixture) -> None:
+    """Test that Page.get does not raise SectionError."""
+    mocker.patch(
+        "pywikibot_extensions.page.pywikibot.page.BasePage.get",
+        side_effect=pywikibot.exceptions.SectionError(
+            "'abc' is not a valid section of Project:Sandbox"
+        ),
+    )
+    Page(SITE, "Project:Sandbox#abc").get()
+
+
 @pytest.mark.parametrize(
     "wikilink, namespace, expected",
     [


### PR DESCRIPTION
[T422859](https://phabricator.wikimedia.org/T422859)